### PR TITLE
fix(payment option): adapt for withdrawal

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,10 @@ const s = fileNames.reduce((sum, fileName) => {
   if (!json.body.StatementHierarchyContainerRTO) {
     return sum;
   }
-  const s = json.body.StatementHierarchyContainerRTO.paymentprofiles.creditcards.paid.reduce((sum, p) => {
+
+  // payment via creditcard vs withdrawal
+  const rides = json.body.StatementHierarchyContainerRTO.paymentprofiles.creditcards ? json.body.StatementHierarchyContainerRTO.paymentprofiles.creditcards.paid : json.body.StatementHierarchyContainerRTO.paymentprofiles.withdrawal.open;
+  const s = rides.reduce((sum, p) => {
     const x = p.amountGross.replace(/EUR (\d+.\d+)/, '$1')
     return sum + parseFloat(x);
   }, 0);
@@ -69,7 +72,8 @@ fileNames.forEach(fileName => {
     return;
   }
 
-  const paidInvoices = json.body.StatementHierarchyContainerRTO.paymentprofiles.creditcards.paid;
+  // payment via creditcard vs withdrawal
+  const paidInvoices = json.body.StatementHierarchyContainerRTO.paymentprofiles.creditcards ? json.body.StatementHierarchyContainerRTO.paymentprofiles.creditcards.paid : json.body.StatementHierarchyContainerRTO.paymentprofiles.withdrawal.open;
   if (!paidInvoices) {
     return;
   }


### PR DESCRIPTION
Hey there!
Great work on that script. It really saved me a lot of time I would have spend clicking through Car2Go's UI. Downloading like 200 invoices that way takes for ever... 

\<rant\>
No thanks to you Mr. @car2go ! A Bulk download feature would  we be greatly appreciated.
\</rant\>

I fixed your script to allow for invoices payed by withdrawal. There were 2 places I had to add a check if the `creditcard` object is defined or not and fallback to withdrawal if so. And yes, withdrawal seems to return rides only as `open`.

If you want I can rewrite this PR to make payment type a script parameter. 

Cheers,
Lukas 
